### PR TITLE
fix so that nowprinting.eps comes to exist on pdf

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -9,7 +9,7 @@
 % See the \addtolength command later in the file to balance the column lengths
 % on the last page of the document
 
-\usepackage[dvipdfmx]{graphicx}
+\usepackage{graphicx}
 \graphicspath{{figs/}}
 \usepackage{amsmath}
 \usepackage{amssymb}


### PR DESCRIPTION
In the original version, nowprinting.eps does not exist on the main.pdf after make command. 
This problem was solved by this change.