### PR TITLE
Add ~ command between Fig. or Table and reference number

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -17,8 +17,8 @@
 \usepackage{algpseudocode}
 \usepackage{times}
 %
-\newcommand{\figref}[1]{Fig.\ref{figure:#1}}
-\newcommand{\tabref}[1]{Table \ref{table:#1}}
+\newcommand{\figref}[1]{Fig.~\ref{figure:#1}}
+\newcommand{\tabref}[1]{Table~\ref{table:#1}}
 \newcommand{\argmax}{\operatornamewithlimits{argmax}}
 \newcommand{\argmin}{\operatornamewithlimits{argmin}}
 


### PR DESCRIPTION
I add `~` command between `Fig.` or `Table` and reference number based on `root.pdf` in http://ras.papercept.net/conferences/support/tex.php

For example,
before: `Fig.1`
after: `Fig. 1`