### PR TITLE
Import small update of ieeeconf.cls

### DIFF
--- a/ieeeconf.cls
+++ b/ieeeconf.cls
@@ -661,7 +661,7 @@
 %
 %
 %
-\ProvidesClass{cssconf}[2004/1/15 revision V1.6b by Pradeep Misra]
+\ProvidesClass{ieeeconf}[2016/4/23 revision V1.6b by Pradeep Misra]
 %\ProvidesClass{IEEEtran}[2002/11/18 revision V1.6b by Michael Shell]
 %\typeout{-- See the "IEEEtran_HOWTO" manual for usage information.}
 %\typeout{-- The source comments contain changelog notes.}


### PR DESCRIPTION
Use new ieeeconf.cls in ieeeconf.zip downloaded from http://ras.papercept.net/conferences/support/tex.php on 2019/10/23.
Related to #6 .
This PR does not influence PDF creation.
It is just for importing latest ieeeconf.cls