### PR TITLE
Fix precise & xenial & bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
+  - os: linux
+    dist: xenial
+    sudo: required
+  - os: linux
+    dist: bionic
+    sudo: required
   - os: osx
   allow_failures:
   - os: osx
@@ -25,5 +31,5 @@ deploy:
   file: main.pdf
   skip_cleanup: true
   on:
-    repo: furushchev/ieee-report-template
+    repo: jsk-report-template/ieee-report
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 TARGET := main
 
 OS := $(shell uname -s)
+VERSION := $(shell lsb_release -rs 2> /dev/null)
 LATEXMK := $(shell command -v latexmk 2> /dev/null)
 LATEXMK_OPTION := -time -recorder -rules
 LATEXMK_EXEC := latexmk $(LATEXMK_OPTION)
@@ -30,7 +31,11 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
+ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
+else
+	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk
+endif
 endif
 ifeq ($(OS), Darwin)
 	brew tap caskroom/cask && brew cask install -v mactex && sudo tlmgr update --self --all

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifeq ($(VERSION), 12.04)
 else ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 else
-	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk
+	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra texlive-font-utils xdvik-ja gv latexmk
 endif
 endif
 ifeq ($(OS), Darwin)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
-ifeq ($(VERSION), 14.04)
+ifeq ($(VERSION), 12.04)
+	sudo apt-get install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
+else ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 else
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ based on http://ras.papercept.net/conferences/support/tex.php
 # only for ubuntu 12.04
 $ sudo apt-add-repository ppa:texlive-backports/ppa
 $ sudo apt-get update
+$ sudo apt-get install lsb-release
 ```
 
 ### 2. Edit LaTeX files


### PR DESCRIPTION
Includes #8 
Similar to https://github.com/jsk-report-template/robomech-template/pull/3, but this PR additionally installs `texlive-font-utils` on xenial and bionic.
This is because [this repo uses pdflatex](https://github.com/jsk-report-template/ieee-report/blob/ae086ff1ad6296ef1041dce518cfcccf122ee0b2/latexmkrc#L1) and pdflatex seems to use `epstopdf`, which is included in `texlive-font-utils`:
https://www.randomhacks.co.uk/how-to-install-epstopdf-on-ubuntu/

In contrast, https://github.com/jsk-report-template/si-template uses dvipdf, so `texlive-font-utils` is not required:
https://github.com/jsk-report-template/si-template/blob/b406380fb51f4372d6d4c83d25531ea654592c7e/latexmkrc#L4 